### PR TITLE
add onlyIfDevelopment entry file for easier webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ overlay: 'webpack-serve-overlay/onlyIfDevelopment'
 
 and you'll be away laughing.
 
+_NOTE: If you are using the default `webpack-hot-client` options, you will want to make sure that this is **not** your first entry. [More info](https://github.com/webpack-contrib/webpack-serve/issues/119#issuecomment-401502247)_  
+
 For a more custom installation, you can alternatively require the overlay at the top of your `index.jsx` (or equivalent):
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ Install the package:
 npm i webpack-serve-overlay
 ```
 
-Then require the overlay at the top of your `index.jsx` (or equivalent):
+Then add the following entry to the [`entry` object](https://webpack.js.org/configuration/entry-context/#entry) in your webpack config:
+
+```javascript
+overlay: 'webpack-serve-overlay/onlyIfDevelopment'
+```
+
+and you'll be away laughing.
+
+For a more custom installation, you can alternatively require the overlay at the top of your `index.jsx` (or equivalent):
 
 ```javascript
 // becomes dead code in builds other than dev,
@@ -23,7 +31,7 @@ if(process.env.NODE_ENV === 'development') {
 }
 ```
 
-and you'll be away laughing.
+
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ npm i webpack-serve-overlay
 Then add the following entry to the [`entry` object](https://webpack.js.org/configuration/entry-context/#entry) in your webpack config:
 
 ```javascript
-overlay: 'webpack-serve-overlay/onlyIfDevelopment'
+entry: {
+  ...
+  overlay: 'webpack-serve-overlay/onlyIfDevelopment'
+}
 ```
 
 and you'll be away laughing.

--- a/onlyIfDevelopment.js
+++ b/onlyIfDevelopment.js
@@ -1,0 +1,3 @@
+if (process.env.NODE_ENV === 'development') {
+  require('./errorOverlay')
+}


### PR DESCRIPTION
- add documentation for this option and leave the previous installation
  docs as an alternative "custom installation"

I based the docs off of the [previous commit that mentioned entry files](https://github.com/G-Rath/webpack-serve-overlay/commit/a99448cab7dc2facdae3fc948a17d995fee16f1a), with a few modifications:
- Added a link to webpack `entry` config since it's a bit of an advanced topic
- Removed `require.resolve` as I don't believe it's necessary (I didn't need to use it in [my webpack config](https://github.com/agilgur5/front-end-base/tree/only-if-production), though I'm not sure if there's a circumstance in which it would be necessary)

Sorry, my formatter removed whitespace at the end of lines automatically, I can remove those from the commit if needed.

Having looked at the past docs commit, I can see that my usage is a bit different than the way you've used it / seen it. I didn't add a new entry (and therefore no new `<script>` tag), I added it to the array in my entry, i.e.

```
entry: {
  main: ['webpack-serve-overlay/onlyIfProduction', './main.js']
}
```
See the link above for full context in my boilerplate repo.
**EDIT**: I definitely think having it as a separate / new entry is the ideal usage as separate entrypoints / script tags ensures the overlay always shows up as its separate, isolated bundle will never fail to compile. In that case, excluding the overlay script tag from production HTML would also be ideal to have as little production impact as possible. Even with `onlyIfProduction`, webpack's bundling code will still create a tiny bundle of JS that does nothing (not optimal, but not particularly harmful either).

Related to #5 